### PR TITLE
fix broken URL http://ethercis.github.io => http://ethercis.org/

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -6,7 +6,7 @@ Xmas Edition 12/24/2015 3:54:43 PM
 What is it?
 -----------
 
-A brief introduction to Ethercis is given [here](http://ethercis.github.io/)
+A brief introduction to Ethercis is given [here](http://ethercis.org/)
 
 Project Structure
 ---


### PR DESCRIPTION
Hi @chevalleyc I presume the broken (404) link should point to http://ethercis.org/ so here's a PR that fixes it.

Marcus